### PR TITLE
Use starman so that we can reload the app without restarting docker-compose itself

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && \
     chmod +x cpm && mv cpm /usr/local/bin && \
     curl -skL --compressed https://cpanmin.us > cpanm && \
     chmod +x cpanm && mv cpanm /usr/local/bin && \
-    cpanm -n IPC::Run && \
+    cpanm -n IPC::Run Starman && \
     curl -skL https://raw.githubusercontent.com/andk/pause/master/cpanfile > cpanfile && \
 #    cpm install -g
     cpanm --installdeps -n .

--- a/docker/app/docker-entrypoint.sh
+++ b/docker/app/docker-entrypoint.sh
@@ -64,4 +64,4 @@ chmod 0600 /var/spool/cron/crontabs/root
 exec rsyslogd &
 exec cron -L1 &
 
-plackup ./app_2017.psgi
+starman --workers 1 -E development --pid=/var/run/pause_web.pid ./app_2017.psgi


### PR DESCRIPTION
Currently we need to restart docker-compose itself to reload web app, but it's too tedious when you actively develop the app. With this PR, you can send HUP to starman by 
```
$ docker-compose exec app bash -c 'kill -s HUP `cat /var/run/pause_web.pid`'
```

Right now we need to limit the number of workers to 1 because of an issue in PAUSE::Web. I'll make another PR to mitigate it later.